### PR TITLE
Support Wezterm packaged by Nix / NixOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,15 @@ export function createSupportsHyperlinks(stream) {
 			}
 
 			case 'WezTerm': {
-				return version.major >= 20_200_620;
+				// WezTerm packaged by Nix uses their own version scheme.
+				if (/^0-unstable-\d{4}-\d{2}-\d{2}$/.test(TERM_PROGRAM_VERSION)) {
+					const date = TERM_PROGRAM_VERSION.slice('0-unstable-'.length);
+					return date >= '2020-06-20';
+				}
+
+				// This number is a date and reads better grouped as such.
+				// eslint-disable-next-line unicorn/numeric-separators-style
+				return version.major >= 2020_06_20;
 			}
 
 			case 'vscode': {

--- a/test.js
+++ b/test.js
@@ -135,6 +135,30 @@ test('not supported WezTerm 20200608, tty stream', t => {
 	}));
 });
 
+test('supported WezTerm 20200620 packaged by Nix, tty stream', t => {
+	t.true(isSupported({
+		env: {
+			TERM_PROGRAM: 'WezTerm',
+			TERM_PROGRAM_VERSION: '0-unstable-2020-06-20',
+		},
+		stream: {
+			isTTY: true,
+		},
+	}));
+});
+
+test('not supported WezTerm 20200608 packaged by Nix, tty stream', t => {
+	t.false(isSupported({
+		env: {
+			TERM_PROGRAM: 'WezTerm',
+			TERM_PROGRAM_VERSION: '0-unstable-2020-06-08',
+		},
+		stream: {
+			isTTY: true,
+		},
+	}));
+});
+
 test('not supported vscode <= 1.0 no stream supplied', t => {
 	t.false(isSupported({
 		env: {


### PR DESCRIPTION
Nix [uses a custom version string when packaging Wezterm](https://github.com/NixOS/nixpkgs/blob/8eaee110344796db060382e15d3af0a9fc396e0e/pkgs/by-name/we/wezterm/package.nix#L31-L42), which doesn't always match the official nightlies.

Detect this format and match on it, using the same underlying date limits.

