### PR TITLE
Add Zed terminal support

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ export function createSupportsHyperlinks(stream) {
 					return true;
 				}
 
-				// eslint-disable-next-line no-mixed-operators
+				// eslint-disable-next-line @stylistic/no-mixed-operators
 				return version.major > 1 || version.major === 1 && version.minor >= 72;
 			}
 

--- a/index.js
+++ b/index.js
@@ -115,7 +115,12 @@ export function createSupportsHyperlinks(stream) {
 			case 'ghostty': {
 				return true;
 			}
-			// No default
+
+			case 'zed': {
+				return true;
+			}
+
+		// No default
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"node": ">=20"
 	},
 	"scripts": {
-		"test": "xo && ava && tsc index.d.ts",
+		"test": "xo && ava && tsc --lib es2022 index.d.ts",
 		"lint": "xo",
 		"lint:fix": "xo --fix"
 	},

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
 		"node": ">=20"
 	},
 	"scripts": {
-		"test": "xo && ava && tsc index.d.ts"
+		"test": "xo && ava && tsc index.d.ts",
+		"lint": "xo",
+		"lint:fix": "xo --fix"
 	},
 	"files": [
 		"index.js",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
 	],
 	"dependencies": {
 		"has-flag": "^5.0.1",
-		"supports-color": "^10.0.0"
+		"supports-color": "^10.2.2"
 	},
 	"devDependencies": {
-		"ava": "^6.2.0",
+		"ava": "^6.4.1",
 		"codecov": "^3.8.3",
-		"typescript": "^5.8.2",
-		"xo": "^0.60.0"
+		"typescript": "^5.9.3",
+		"xo": "^1.2.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
 		"node": ">=20"
 	},
 	"scripts": {
-		"test": "xo && ava && tsc --lib es2022 index.d.ts",
-		"lint": "xo",
-		"lint:fix": "xo --fix"
+		"test": "xo && ava && tsc --lib es2022 index.d.ts"
 	},
 	"files": [
 		"index.js",

--- a/test.js
+++ b/test.js
@@ -349,6 +349,25 @@ test('supported in kitty', t => {
 	}));
 });
 
+test('supported zed no stream supplied', t => {
+	t.true(isSupported({
+		env: {
+			TERM_PROGRAM: 'zed',
+		},
+	}));
+});
+
+test('supported zed tty stream', t => {
+	t.true(isSupported({
+		env: {
+			TERM_PROGRAM: 'zed',
+		},
+		stream: {
+			isTTY: true,
+		},
+	}));
+});
+
 test('empty env not supported', t => {
 	t.false(isSupported({env: {}}));
 });

--- a/test.js
+++ b/test.js
@@ -30,67 +30,57 @@ const isSupported = ({
 };
 
 test('supported iTerm.app 3.1, tty stream', t => {
-	t.true(isSupported(
-		{
-			env: {
-				TERM_PROGRAM: 'iTerm.app',
-				TERM_PROGRAM_VERSION: '3.1.0',
-			},
-			stream: {
-				isTTY: true,
-			},
+	t.true(isSupported({
+		env: {
+			TERM_PROGRAM: 'iTerm.app',
+			TERM_PROGRAM_VERSION: '3.1.0',
 		},
-	));
+		stream: {
+			isTTY: true,
+		},
+	}));
 });
 
 test('supported iTerm.app 3.1, no stream supplied', t => {
-	t.true(isSupported(
-		{
-			env: {
-				TERM_PROGRAM: 'iTerm.app',
-				TERM_PROGRAM_VERSION: '3.1.0',
-			},
+	t.true(isSupported({
+		env: {
+			TERM_PROGRAM: 'iTerm.app',
+			TERM_PROGRAM_VERSION: '3.1.0',
 		},
-	));
+	}));
 });
 
 test('supported iTerm.app 4.0, no stream supplied', t => {
-	t.true(isSupported(
-		{
-			env: {
-				TERM_PROGRAM: 'iTerm.app',
-				TERM_PROGRAM_VERSION: '4.0.0',
-			},
+	t.true(isSupported({
+		env: {
+			TERM_PROGRAM: 'iTerm.app',
+			TERM_PROGRAM_VERSION: '4.0.0',
 		},
-	));
+	}));
 });
 
 test('not supported iTerm 3.0, tty stream', t => {
-	t.false(isSupported(
-		{
-			env: {
-				TERM_PROGRAM: 'iTerm.app',
-				TERM_PROGRAM_VERSION: '3.0.0',
-			},
-			stream: {
-				isTTY: true,
-			},
+	t.false(isSupported({
+		env: {
+			TERM_PROGRAM: 'iTerm.app',
+			TERM_PROGRAM_VERSION: '3.0.0',
 		},
-	));
+		stream: {
+			isTTY: true,
+		},
+	}));
 });
 
 test('not supported iTerm 3.1, non-tty stream', t => {
-	t.false(isSupported(
-		{
-			env: {
-				TERM_PROGRAM: 'iTerm.app',
-				TERM_PROGRAM_VERSION: '3.1.0',
-			},
-			stream: {
-				isTTY: false,
-			},
+	t.false(isSupported({
+		env: {
+			TERM_PROGRAM: 'iTerm.app',
+			TERM_PROGRAM_VERSION: '3.1.0',
 		},
-	));
+		stream: {
+			isTTY: false,
+		},
+	}));
 });
 
 test('not supported WezTerm 20200620 no stream supplied', t => {


### PR DESCRIPTION
## Summary

- Add support for Zed terminal (`TERM_PROGRAM === 'zed'`)
- Add lint scripts to package.json.
- Update deps and fix eslint rule for `xo@1.x` compatibility